### PR TITLE
fix: add `false` parameter to class_exists() guards to prevent autoloader collisions

### DIFF
--- a/includes/admin/health/class-site_health.php
+++ b/includes/admin/health/class-site_health.php
@@ -5,7 +5,7 @@ namespace OES\Admin\Health;
 if (!defined('ABSPATH')) exit;
 
 
-if (!class_exists('\OES\Admin\Health\Site_Health')) {
+if (!class_exists('\OES\Admin\Health\Site_Health', false)) {
 
     /**
      * The OES Site Health class responsible for populating OES debug information in WordPress Site Health.

--- a/includes/admin/operations/class-display_builder.php
+++ b/includes/admin/operations/class-display_builder.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-if (!class_exists('Display_Builder')) :
+if (!class_exists('Display_Builder', false)) :
 
     /**
      * Class Display_Builder

--- a/includes/admin/operations/class-executor.php
+++ b/includes/admin/operations/class-executor.php
@@ -8,7 +8,7 @@ if (!defined('ABSPATH')) {
 
 use WP_Error;
 
-if (!class_exists('Executor')) :
+if (!class_exists('Executor', false)) :
 
     /**
      * Class Executor

--- a/includes/admin/operations/class-operation.php
+++ b/includes/admin/operations/class-operation.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-if (!class_exists('Operation')) :
+if (!class_exists('Operation', false)) :
 
     /**
      * Class Operation

--- a/includes/admin/operations/class-repository.php
+++ b/includes/admin/operations/class-repository.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-if (!class_exists('Repository')) :
+if (!class_exists('Repository', false)) :
 
     /**
      * Class Repository

--- a/includes/admin/pages/class-container.php
+++ b/includes/admin/pages/class-container.php
@@ -9,9 +9,9 @@ namespace OES\Admin;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Page')) oes_include('admin/pages/class-page.php');
+if (!class_exists('Page', false)) oes_include('admin/pages/class-page.php');
 
-if (!class_exists('Container')) :
+if (!class_exists('Container', false)) :
 
     /**
      * Class Container

--- a/includes/admin/pages/class-module_page.php
+++ b/includes/admin/pages/class-module_page.php
@@ -9,7 +9,7 @@ namespace OES\Admin;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Module_Page')) :
+if (!class_exists('Module_Page', false)) :
 
     /**
      * Class Module_Page

--- a/includes/admin/pages/class-page.php
+++ b/includes/admin/pages/class-page.php
@@ -9,7 +9,7 @@ namespace OES\Admin;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Page')) :
+if (!class_exists('Page', false)) :
 
     /**
      * Class Page

--- a/includes/admin/pages/class-subpage.php
+++ b/includes/admin/pages/class-subpage.php
@@ -9,9 +9,9 @@ namespace OES\Admin;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Page')) oes_include('admin/pages/class-page.php');
+if (!class_exists('Page', false)) oes_include('admin/pages/class-page.php');
 
-if (!class_exists('Subpage')) :
+if (!class_exists('Subpage', false)) :
 
     /**
      * Class Subpage

--- a/includes/admin/tools/class-factory_service.php
+++ b/includes/admin/tools/class-factory_service.php
@@ -12,7 +12,7 @@ use Throwable;
 use function OES\ACF\is_acf_generated_key;
 use function OES\Factory\get_factory_posts;
 
-if (class_exists('Factory_Service')) exit;
+if (class_exists('Factory_Service', false)) exit;
 
 /**
  * Class Service

--- a/includes/admin/tools/class-form_table.php
+++ b/includes/admin/tools/class-form_table.php
@@ -7,7 +7,7 @@
 
 namespace OES\Admin\Tools;
 
-if (class_exists('Form_Table')) exit;
+if (class_exists('Form_Table', false)) exit;
 
 /**
  * Class Form_Table

--- a/includes/admin/tools/class-tool-batch.php
+++ b/includes/admin/tools/class-tool-batch.php
@@ -11,7 +11,7 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
 use WP_Query;
 
-if (class_exists('Batch')) exit;
+if (class_exists('Batch', false)) exit;
 
 /**
  * Class Batch

--- a/includes/admin/tools/class-tool-export.php
+++ b/includes/admin/tools/class-tool-export.php
@@ -13,7 +13,7 @@ use WP_Query;
 use WP_Term;
 use WP_Post;
 
-if (class_exists('Export')) exit;
+if (class_exists('Export', false)) exit;
 
 /**
  * Class Export

--- a/includes/admin/tools/class-tool-factory.php
+++ b/includes/admin/tools/class-tool-factory.php
@@ -12,7 +12,7 @@ use function OES\Factory\get_factory_posts;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (class_exists('Factory')) exit;
+if (class_exists('Factory', false)) exit;
 
 /**
  * Class Factory

--- a/includes/admin/tools/class-tool-import.php
+++ b/includes/admin/tools/class-tool-import.php
@@ -10,7 +10,7 @@ use WP_Term;
 use function OES\Admin\Operations\insert_operation;
 use function OES\Admin\Operations\get_max_temp;
 
-if (!class_exists('Import')) :
+if (!class_exists('Import', false)) :
 
     /**
      * Class Import

--- a/includes/admin/tools/class-tool-model.php
+++ b/includes/admin/tools/class-tool-model.php
@@ -12,7 +12,7 @@ use function OES\Model\import_model_from_json;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Model')) :
+if (!class_exists('Model', false)) :
 
     /**
      * Class Model

--- a/includes/admin/tools/class-tool-shortcode.php
+++ b/includes/admin/tools/class-tool-shortcode.php
@@ -4,9 +4,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('\OES\Admin\Tools\Config')) oes_include('admin/tools/config/class-config.php');
+if (!class_exists('\OES\Admin\Tools\Config', false)) oes_include('admin/tools/config/class-config.php');
 
-if (!class_exists('Shortcode')) :
+if (!class_exists('Shortcode', false)) :
 
     /**
      * Class Shortcode

--- a/includes/admin/tools/class-tool.php
+++ b/includes/admin/tools/class-tool.php
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly
 use function OES\Admin\add_oes_notice_after_refresh;
 use function OES\Admin\get_admin_note_html;
 
-if (!class_exists('\OES\Admin\Tools\Tool')) {
+if (!class_exists('\OES\Admin\Tools\Tool', false)) {
 
     /**
      * Class Tool

--- a/includes/admin/tools/config/class-config-admin_columns.php
+++ b/includes/admin/tools/config/class-config-admin_columns.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Config')) oes_include('admin/tools/config/class-config.php');
+if (!class_exists('Config', false)) oes_include('admin/tools/config/class-config.php');
 
-if (class_exists('Admin_Columns')) exit;
+if (class_exists('Admin_Columns', false)) exit;
 
 /**
  * Class Admin Columns

--- a/includes/admin/tools/config/class-config-admin_container.php
+++ b/includes/admin/tools/config/class-config-admin_container.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Config')) oes_include('admin/tools/config/class-config.php');
+if (!class_exists('Config', false)) oes_include('admin/tools/config/class-config.php');
 
-if (class_exists('Admin_Container')) exit;
+if (class_exists('Admin_Container', false)) exit;
 
 /**
  * Class Admin_Container

--- a/includes/admin/tools/config/class-config-application.php
+++ b/includes/admin/tools/config/class-config-application.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Config')) oes_include('admin/tools/config/class-config.php');
+if (!class_exists('Config', false)) oes_include('admin/tools/config/class-config.php');
 
-if (class_exists('Application')) exit;
+if (class_exists('Application', false)) exit;
 
 /**
  * Class Application

--- a/includes/admin/tools/config/class-config-module.php
+++ b/includes/admin/tools/config/class-config-module.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Config')) oes_include('admin/tools/config/class-config.php');
+if (!class_exists('Config', false)) oes_include('admin/tools/config/class-config.php');
 
-if (class_exists('Module')) exit;
+if (class_exists('Module', false)) exit;
 
 /**
  * Class Module

--- a/includes/admin/tools/config/class-config-schema.php
+++ b/includes/admin/tools/config/class-config-schema.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('\OES\Admin\Tools\Config')) oes_include('admin/tools/config/class-config.php');
+if (!class_exists('\OES\Admin\Tools\Config', false)) oes_include('admin/tools/config/class-config.php');
 
-if (class_exists('Schema')) exit;
+if (class_exists('Schema', false)) exit;
 
 /**
  * Class Schema

--- a/includes/admin/tools/config/class-config-schema_oes.php
+++ b/includes/admin/tools/config/class-config-schema_oes.php
@@ -9,10 +9,10 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Config')) oes_include('admin/tools/config/class-config.php');
-if (!class_exists('Schema')) oes_include('admin/tools/config/class-config-schema.php');
+if (!class_exists('Config', false)) oes_include('admin/tools/config/class-config.php');
+if (!class_exists('Schema', false)) oes_include('admin/tools/config/class-config-schema.php');
 
-if (class_exists('Schema_OES')) exit;
+if (class_exists('Schema_OES', false)) exit;
 
 /**
  * Class Schema_OES

--- a/includes/admin/tools/config/class-config-schema_oes_archive.php
+++ b/includes/admin/tools/config/class-config-schema_oes_archive.php
@@ -9,10 +9,10 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Config')) oes_include('admin/tools/config/class-config.php');
-if (!class_exists('Schema')) oes_include('admin/tools/config/class-config-schema.php');
+if (!class_exists('Config', false)) oes_include('admin/tools/config/class-config.php');
+if (!class_exists('Schema', false)) oes_include('admin/tools/config/class-config-schema.php');
 
-if (class_exists('Schema_OES_Archive')) exit;
+if (class_exists('Schema_OES_Archive', false)) exit;
 
 /**
  * Class Schema_OES_Archive

--- a/includes/admin/tools/config/class-config-schema_oes_single.php
+++ b/includes/admin/tools/config/class-config-schema_oes_single.php
@@ -9,10 +9,10 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Config')) oes_include('admin/tools/config/class-config.php');
-if (!class_exists('Schema')) oes_include('admin/tools/config/class-config-schema.php');
+if (!class_exists('Config', false)) oes_include('admin/tools/config/class-config.php');
+if (!class_exists('Schema', false)) oes_include('admin/tools/config/class-config-schema.php');
 
-if (class_exists('Schema_OES_Single')) exit;
+if (class_exists('Schema_OES_Single', false)) exit;
 
 /**
  * Class Schema_OES_Single

--- a/includes/admin/tools/config/class-config-theme_colors.php
+++ b/includes/admin/tools/config/class-config-theme_colors.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Config')) oes_include('admin/tools/config/class-config.php');
+if (!class_exists('Config', false)) oes_include('admin/tools/config/class-config.php');
 
-if (class_exists('Theme_Colors')) exit;
+if (class_exists('Theme_Colors', false)) exit;
 
 /**
  * Class Theme_Colors

--- a/includes/admin/tools/config/class-config-theme_date.php
+++ b/includes/admin/tools/config/class-config-theme_date.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Config')) oes_include('admin/tools/config/class-config.php');
+if (!class_exists('Config', false)) oes_include('admin/tools/config/class-config.php');
 
-if (class_exists('Theme_Date')) exit;
+if (class_exists('Theme_Date', false)) exit;
 
 /**
  * Class Theme_Date

--- a/includes/admin/tools/config/class-config-theme_index_pages.php
+++ b/includes/admin/tools/config/class-config-theme_index_pages.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Config')) oes_include('admin/tools/config/class-config.php');
+if (!class_exists('Config', false)) oes_include('admin/tools/config/class-config.php');
 
-if (class_exists('Theme_Index_Pages')) exit;
+if (class_exists('Theme_Index_Pages', false)) exit;
 
 /**
  * Class Theme_Index_Pages

--- a/includes/admin/tools/config/class-config-theme_labels.php
+++ b/includes/admin/tools/config/class-config-theme_labels.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Config')) oes_include('admin/tools/config/class-config.php');
+if (!class_exists('Config', false)) oes_include('admin/tools/config/class-config.php');
 
-if (class_exists('Theme_Labels')) exit;
+if (class_exists('Theme_Labels', false)) exit;
 
 /**
  * Class Theme_Labels

--- a/includes/admin/tools/config/class-config-theme_labels_general.php
+++ b/includes/admin/tools/config/class-config-theme_labels_general.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Theme_Labels')) oes_include('admin/tools/config/class-config-theme_labels.php');
+if (!class_exists('Theme_Labels', false)) oes_include('admin/tools/config/class-config-theme_labels.php');
 
-if (class_exists('Theme_Labels_General')) exit;
+if (class_exists('Theme_Labels_General', false)) exit;
 
 /**
  * Class Theme_Labels_General

--- a/includes/admin/tools/config/class-config-theme_labels_media.php
+++ b/includes/admin/tools/config/class-config-theme_labels_media.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Theme_Labels')) oes_include('admin/tools/config/class-config-theme_labels.php');
+if (!class_exists('Theme_Labels', false)) oes_include('admin/tools/config/class-config-theme_labels.php');
 
-if (class_exists('Theme_Labels_Media')) exit;
+if (class_exists('Theme_Labels_Media', false)) exit;
 
 /**
  * Class Theme_Labels_Media

--- a/includes/admin/tools/config/class-config-theme_labels_objects.php
+++ b/includes/admin/tools/config/class-config-theme_labels_objects.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Theme_Labels')) oes_include('admin/tools/config/class-config-theme_labels.php');
+if (!class_exists('Theme_Labels', false)) oes_include('admin/tools/config/class-config-theme_labels.php');
 
-if (class_exists('Theme_Labels_Objects')) exit;
+if (class_exists('Theme_Labels_Objects', false)) exit;
 
 /**
  * Class Theme_Labels_Objects

--- a/includes/admin/tools/config/class-config-theme_languages.php
+++ b/includes/admin/tools/config/class-config-theme_languages.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Config')) oes_include('admin/tools/config/class-config.php');
+if (!class_exists('Config', false)) oes_include('admin/tools/config/class-config.php');
 
-if (class_exists('Theme_Languages')) exit;
+if (class_exists('Theme_Languages', false)) exit;
 
 /**
  * Class Theme_Languages

--- a/includes/admin/tools/config/class-config-theme_logos.php
+++ b/includes/admin/tools/config/class-config-theme_logos.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Config')) oes_include('admin/tools/config/class-config.php');
+if (!class_exists('Config', false)) oes_include('admin/tools/config/class-config.php');
 
-if (class_exists('Theme_Logos')) exit;
+if (class_exists('Theme_Logos', false)) exit;
 
 /**
  * Class Theme_Logos

--- a/includes/admin/tools/config/class-config-theme_media.php
+++ b/includes/admin/tools/config/class-config-theme_media.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Config')) oes_include('admin/tools/config/class-config.php');
+if (!class_exists('Config', false)) oes_include('admin/tools/config/class-config.php');
 
-if (class_exists('Theme_Media')) exit;
+if (class_exists('Theme_Media', false)) exit;
 
 /**
  * Class Theme_Media

--- a/includes/admin/tools/config/class-config-theme_search.php
+++ b/includes/admin/tools/config/class-config-theme_search.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Config')) oes_include('admin/tools/config/class-config.php');
+if (!class_exists('Config', false)) oes_include('admin/tools/config/class-config.php');
 
-if (class_exists('Theme_Search')) exit;
+if (class_exists('Theme_Search', false)) exit;
 
 /**
  * Class Theme_Search

--- a/includes/admin/tools/config/class-config.php
+++ b/includes/admin/tools/config/class-config.php
@@ -11,9 +11,9 @@ use function OES\Model\get_oes_object_option;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Tools')) oes_include('admin/tools/class-tool.php');
+if (!class_exists('Tools', false)) oes_include('admin/tools/class-tool.php');
 
-if (class_exists('Config')) exit;
+if (class_exists('Config', false)) exit;
 
 /**
  * Class Config

--- a/includes/lod/class-api_interface.php
+++ b/includes/lod/class-api_interface.php
@@ -4,7 +4,7 @@ namespace OES\API;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists(__NAMESPACE__ . 'API_Interface')) {
+if (!class_exists(__NAMESPACE__ . 'API_Interface', false)) {
 
     /**
      * API Interface

--- a/includes/lod/class-display_helper.php
+++ b/includes/lod/class-display_helper.php
@@ -4,7 +4,7 @@ namespace OES\API;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('\OES\API\Display_Helper')) {
+if (!class_exists('\OES\API\Display_Helper', false)) {
 
     /**
      * API Interface

--- a/includes/lod/class-lod_config.php
+++ b/includes/lod/class-lod_config.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Config')) oes_include('admin/tools/config/class-config.php');
+if (!class_exists('Config', false)) oes_include('admin/tools/config/class-config.php');
 
-if (!class_exists('LOD')) {
+if (!class_exists('LOD', false)) {
 
     /**
      * Class LOD

--- a/includes/lod/class-lod_schema.php
+++ b/includes/lod/class-lod_schema.php
@@ -4,9 +4,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Schema')) oes_include('admin/tools/config/class-config-schema.php');
+if (!class_exists('Schema', false)) oes_include('admin/tools/config/class-config-schema.php');
 
-if (!class_exists('LOD_Schema')) {
+if (!class_exists('LOD_Schema', false)) {
 
     /**
      * Class LOD_Schema

--- a/includes/lod/class-rest_api.php
+++ b/includes/lod/class-rest_api.php
@@ -4,7 +4,7 @@ namespace OES\API;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Rest_API')) {
+if (!class_exists('Rest_API', false)) {
 
     /**
      * Rest API

--- a/includes/lod/geonames/class-geonames.php
+++ b/includes/lod/geonames/class-geonames.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('LOD')) oes_include('lod/class-lod_config.php');
+if (!class_exists('LOD', false)) oes_include('lod/class-lod_config.php');
 
-if (!class_exists('Geonames')) {
+if (!class_exists('Geonames', false)) {
 
     /**
      * Class Geonames

--- a/includes/lod/geonames/class-geonames_api.php
+++ b/includes/lod/geonames/class-geonames_api.php
@@ -4,7 +4,7 @@ namespace OES\API;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Geonames_API')) {
+if (!class_exists('Geonames_API', false)) {
 
     /**
      * Class Geonames_API

--- a/includes/lod/geonames/class-geonames_interface.php
+++ b/includes/lod/geonames/class-geonames_interface.php
@@ -4,7 +4,7 @@ namespace OES\API;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('Geonames_Interface')) {
+if (!class_exists('Geonames_Interface', false)) {
 
     /**
      * Geonames Interface.

--- a/includes/lod/gnd/class-gnd.php
+++ b/includes/lod/gnd/class-gnd.php
@@ -4,9 +4,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('LOD')) oes_include('lod/class-lod_config.php');
+if (!class_exists('LOD', false)) oes_include('lod/class-lod_config.php');
 
-if (!class_exists('GND')) {
+if (!class_exists('GND', false)) {
 
     /**
      * Class GND

--- a/includes/lod/gnd/class-gnd_api.php
+++ b/includes/lod/gnd/class-gnd_api.php
@@ -4,7 +4,7 @@ namespace OES\API;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('GND_API')) {
+if (!class_exists('GND_API', false)) {
 
     /**
      * Class GND_API

--- a/includes/lod/gnd/class-gnd_display_helper.php
+++ b/includes/lod/gnd/class-gnd_display_helper.php
@@ -2,7 +2,7 @@
 
 namespace OES\API;
 
-if (!class_exists('\OES\API\GND_Display_Helper')) {
+if (!class_exists('\OES\API\GND_Display_Helper', false)) {
     class GND_Display_Helper extends Display_Helper
     {
 

--- a/includes/lod/gnd/class-gnd_interface.php
+++ b/includes/lod/gnd/class-gnd_interface.php
@@ -4,7 +4,7 @@ namespace OES\API;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('GND_Interface')) {
+if (!class_exists('GND_Interface', false)) {
 
     /**
      * GND Interface

--- a/includes/lod/hmml/class-hmml.php
+++ b/includes/lod/hmml/class-hmml.php
@@ -4,9 +4,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('LOD')) oes_include('lod/class-lod_config.php');
+if (!class_exists('LOD', false)) oes_include('lod/class-lod_config.php');
 
-if (!class_exists('HMML')) {
+if (!class_exists('HMML', false)) {
 
     /**
      * Class HMML

--- a/includes/lod/hmml/class-hmml_api.php
+++ b/includes/lod/hmml/class-hmml_api.php
@@ -4,7 +4,7 @@ namespace OES\API;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('HMML_API')) {
+if (!class_exists('HMML_API', false)) {
 
     /**
      * HMML API integration

--- a/includes/lod/hmml/class-hmml_interface.php
+++ b/includes/lod/hmml/class-hmml_interface.php
@@ -4,7 +4,7 @@ namespace OES\API;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('HMML_Interface')) {
+if (!class_exists('HMML_Interface', false)) {
 
     /**
      * HMML Interface

--- a/includes/lod/loc/class-loc.php
+++ b/includes/lod/loc/class-loc.php
@@ -9,9 +9,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('LOD')) oes_include('lod/class-lod_config.php');
+if (!class_exists('LOD', false)) oes_include('lod/class-lod_config.php');
 
-if (!class_exists('LoC')) {
+if (!class_exists('LoC', false)) {
 
     /**
      * Class LoC

--- a/includes/lod/loc/class-loc_api.php
+++ b/includes/lod/loc/class-loc_api.php
@@ -4,7 +4,7 @@ namespace OES\API;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('LOC_API')) {
+if (!class_exists('LOC_API', false)) {
 
     /**
      * Class LOC_API

--- a/includes/lod/loc/class-loc_interface.php
+++ b/includes/lod/loc/class-loc_interface.php
@@ -4,7 +4,7 @@ namespace OES\API;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('LOC_Interface')) {
+if (!class_exists('LOC_Interface', false)) {
 
     /**
      * LOC Interface

--- a/includes/lod/orcid/class-orcid.php
+++ b/includes/lod/orcid/class-orcid.php
@@ -4,9 +4,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('LOD')) oes_include('lod/class-lod_config.php');
+if (!class_exists('LOD', false)) oes_include('lod/class-lod_config.php');
 
-if (!class_exists('ORCID')) {
+if (!class_exists('ORCID', false)) {
 
     /**
      * Class ORCID

--- a/includes/lod/orcid/class-orcid_api.php
+++ b/includes/lod/orcid/class-orcid_api.php
@@ -4,7 +4,7 @@ namespace OES\API;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('ORCID_API')) {
+if (!class_exists('ORCID_API', false)) {
 
     /**
      * ORCID API integration

--- a/includes/lod/orcid/class-orcid_interface.php
+++ b/includes/lod/orcid/class-orcid_interface.php
@@ -4,7 +4,7 @@ namespace OES\API;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('ORCID_Interface')) {
+if (!class_exists('ORCID_Interface', false)) {
 
     /**
      * ORCID Interface

--- a/includes/lod/ror/class-ror.php
+++ b/includes/lod/ror/class-ror.php
@@ -4,9 +4,9 @@ namespace OES\Admin\Tools;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('LOD')) oes_include('lod/class-lod_config.php');
+if (!class_exists('LOD', false)) oes_include('lod/class-lod_config.php');
 
-if (!class_exists('ROR')) {
+if (!class_exists('ROR', false)) {
 
     /**
      * Class ROR

--- a/includes/lod/ror/class-ror_api.php
+++ b/includes/lod/ror/class-ror_api.php
@@ -4,7 +4,7 @@ namespace OES\API;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('ROR_API')) {
+if (!class_exists('ROR_API', false)) {
 
     /**
      * ROR API integration

--- a/includes/lod/ror/class-ror_interface.php
+++ b/includes/lod/ror/class-ror_interface.php
@@ -4,7 +4,7 @@ namespace OES\API;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('ROR_Interface')) {
+if (!class_exists('ROR_Interface', false)) {
 
     /**
      * ROR Interface

--- a/includes/rest/class-export.php
+++ b/includes/rest/class-export.php
@@ -6,7 +6,7 @@ use WP_Post;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('\OES\Export\Export')) {
+if (!class_exists('\OES\Export\Export', false)) {
 
 
     /**

--- a/includes/rest/class-json_export.php
+++ b/includes/rest/class-json_export.php
@@ -4,7 +4,7 @@ namespace OES\Export;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('\OES\Export\JSON_Export') && class_exists('\OES\Export\Export')) {
+if (!class_exists('\OES\Export\JSON_Export', false) && class_exists('\OES\Export\Export', false)) {
 
 
     /**

--- a/includes/rest/class-oes_export.php
+++ b/includes/rest/class-oes_export.php
@@ -4,7 +4,7 @@ namespace OES\Export;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('\OES\Export\OES_Export') && class_exists('\OES\Export\Export')) {
+if (!class_exists('\OES\Export\OES_Export', false) && class_exists('\OES\Export\Export', false)) {
 
 
     /**

--- a/includes/rest/class-tei_export.php
+++ b/includes/rest/class-tei_export.php
@@ -4,7 +4,7 @@ namespace OES\Export;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('\OES\Export\TEI_Export') && class_exists('\OES\Export\Export')) {
+if (!class_exists('\OES\Export\TEI_Export', false) && class_exists('\OES\Export\Export', false)) {
 
 
     /**

--- a/includes/theme/data/class-archive.php
+++ b/includes/theme/data/class-archive.php
@@ -4,7 +4,7 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
 use OES\Versioning as Versioning;
 
-if (!class_exists('OES_Archive')) {
+if (!class_exists('OES_Archive', false)) {
 
 
     /**

--- a/includes/theme/data/class-attachment.php
+++ b/includes/theme/data/class-attachment.php
@@ -2,7 +2,7 @@
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('OES_Attachment')) {
+if (!class_exists('OES_Attachment', false)) {
 
     /**
      * Class OES_Attachment

--- a/includes/theme/data/class-index_archive.php
+++ b/includes/theme/data/class-index_archive.php
@@ -2,7 +2,7 @@
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('OES_Index_Archive') && class_exists('OES_Archive')) {
+if (!class_exists('OES_Index_Archive', false) && class_exists('OES_Archive', false)) {
 
 
     /**

--- a/includes/theme/data/class-object.php
+++ b/includes/theme/data/class-object.php
@@ -4,7 +4,7 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
 use function OES\Versioning\get_version_field;
 
-if (!class_exists('OES_Object')) {
+if (!class_exists('OES_Object', false)) {
 
     /**
      * Class OES_Object

--- a/includes/theme/data/class-page.php
+++ b/includes/theme/data/class-page.php
@@ -2,7 +2,7 @@
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('OES_Page')) {
+if (!class_exists('OES_Page', false)) {
 
     /**
      * Class OES_Page

--- a/includes/theme/data/class-post.php
+++ b/includes/theme/data/class-post.php
@@ -7,7 +7,7 @@ use function OES\Versioning\get_translation_id;
 use function OES\Versioning\get_all_version_ids;
 use function OES\Versioning\get_current_version_id;
 
-if (!class_exists('OES_Post')) {
+if (!class_exists('OES_Post', false)) {
 
     /**
      * Class OES_Post

--- a/includes/theme/data/class-post_archive.php
+++ b/includes/theme/data/class-post_archive.php
@@ -2,7 +2,7 @@
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('OES_Post_Archive') && class_exists('OES_Archive')) {
+if (!class_exists('OES_Post_Archive', false) && class_exists('OES_Archive', false)) {
 
 
     /**

--- a/includes/theme/data/class-taxonomy.php
+++ b/includes/theme/data/class-taxonomy.php
@@ -7,7 +7,7 @@
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('OES_Taxonomy')) {
+if (!class_exists('OES_Taxonomy', false)) {
 
     /**
      * Class OES_Taxonomy

--- a/includes/theme/data/class-taxonomy_archive.php
+++ b/includes/theme/data/class-taxonomy_archive.php
@@ -2,7 +2,7 @@
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('OES_Taxonomy_Archive') && class_exists('OES_Archive')) {
+if (!class_exists('OES_Taxonomy_Archive', false) && class_exists('OES_Archive', false)) {
 
 
     /**

--- a/includes/theme/data/class-template_redirect.php
+++ b/includes/theme/data/class-template_redirect.php
@@ -7,7 +7,7 @@
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('OES_Template_Redirect')):
+if (!class_exists('OES_Template_Redirect', false)):
 
     /**
      * Handles data preparation and customization of the template redirect phase in WordPress.

--- a/includes/theme/data/class-term.php
+++ b/includes/theme/data/class-term.php
@@ -2,7 +2,7 @@
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('OES_Term')) {
+if (!class_exists('OES_Term', false)) {
 
     /**
      * Class OES_Term

--- a/includes/theme/figures/class-gallery_panel.php
+++ b/includes/theme/figures/class-gallery_panel.php
@@ -7,7 +7,7 @@
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('OES_Gallery_Panel')) {
+if (!class_exists('OES_Gallery_Panel', false)) {
 
     /**
      * Class OES_Gallery_Panel

--- a/includes/theme/figures/class-image_panel.php
+++ b/includes/theme/figures/class-image_panel.php
@@ -7,7 +7,7 @@
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('OES_Image_Panel')) {
+if (!class_exists('OES_Image_Panel', false)) {
 
     /**
      * Class OES_Image_Panel

--- a/includes/theme/figures/class-panel.php
+++ b/includes/theme/figures/class-panel.php
@@ -7,7 +7,7 @@
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('OES_Panel')) {
+if (!class_exists('OES_Panel', false)) {
 
     /**
      * Class OES_Panel

--- a/includes/theme/filter/class-filter_renderer.php
+++ b/includes/theme/filter/class-filter_renderer.php
@@ -7,7 +7,7 @@
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('OES_Filter_Renderer')) {
+if (!class_exists('OES_Filter_Renderer', false)) {
 
     /**
      * Class OES_Filter_Renderer

--- a/includes/theme/icons/class-icon_manager.php
+++ b/includes/theme/icons/class-icon_manager.php
@@ -10,7 +10,7 @@ namespace OES\Icon;
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
 
-if (!class_exists('\OES\Icon\Manager')) {
+if (!class_exists('\OES\Icon\Manager', false)) {
 
     /**
      * Abstract base class for managing inline SVG icons.

--- a/includes/theme/icons/class-icons.php
+++ b/includes/theme/icons/class-icons.php
@@ -10,7 +10,7 @@ namespace OES\Icon;
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
 
-if (!class_exists('\OES\Icon\Icons')) {
+if (!class_exists('\OES\Icon\Icons', false)) {
 
     /**
      * Concrete icon set for use in the theme or plugin.

--- a/includes/theme/navigation/class-language_switch.php
+++ b/includes/theme/navigation/class-language_switch.php
@@ -5,7 +5,7 @@ namespace OES\Navigation;
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
 
-if (!class_exists('Language_Switch')) {
+if (!class_exists('Language_Switch', false)) {
 
     /**
      * Class Language_Switch

--- a/includes/theme/search/class-search.php
+++ b/includes/theme/search/class-search.php
@@ -4,7 +4,7 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
 use function OES\Versioning\get_parent_id;
 
-if (!class_exists('OES_Search') && class_exists('OES_Archive')) {
+if (!class_exists('OES_Search', false) && class_exists('OES_Archive', false)) {
 
     /**
      * Class OES_Search

--- a/includes/theme/search/class-search_query.php
+++ b/includes/theme/search/class-search_query.php
@@ -7,7 +7,7 @@
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
-if (!class_exists('OES_Search_Query')) {
+if (!class_exists('OES_Search_Query', false)) {
 
     /**
      * Class OES_Search_Query

--- a/includes/theme/search/class-search_results.php
+++ b/includes/theme/search/class-search_results.php
@@ -10,7 +10,7 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly
 use function \OES\Versioning\get_parent_id;
 use function \OES\Versioning\get_version_field;
 
-if (!class_exists('OES_Search_Results')) {
+if (!class_exists('OES_Search_Results', false)) {
 
     /**
      * Class OES_Search_Results


### PR DESCRIPTION
## Zusammenfassung (DE)

Dieser PR fügt den Parameter `false` zu allen `class_exists()`-Guard-Aufrufen in `includes/` hinzu, um Autoloader-Kollisionen mit Drittanbieter-Plugins zu verhindern.

### Problem

Wenn OES Core zusammen mit Plugins wie WooCommerce eingesetzt wird, die eigene PHP-Autoloader registrieren (Action Scheduler, Jetpack Autoloader), führen `class_exists('ClassName')`-Aufrufe ohne `false` dazu, dass diese Autoloader unbeabsichtigt ausgelöst werden. Kurze, unqualifizierte Klassennamen wie `'Config'`, `'Container'` oder `'Page'` werden von externen Autoloadern fälschlicherweise als eigene Klassen erkannt und geladen. Das führt zu Fatal Errors.

### Beobachtete Fehler

1. **`Cannot declare class Action_Scheduler\Migration\Config`** — OES ruft `class_exists('Config')` auf → der Action Scheduler Autoloader matcht `Config` als Migration-Klasse → lädt `migration/Config.php` → beim zweiten Aufruf wird die Klasse doppelt deklariert → Fatal Error.

2. **`Class "OES\Admin\Container" not found`** — OES ruft `class_exists('Container')` auf → der Jetpack Autoloader lädt seine eigene `\Container`-Klasse → der Guard gibt `true` zurück → OES überspringt die eigene Klassendeklaration → späterer Code versucht `OES\Admin\Container` zu instanziieren → Fatal Error.

### Fix

`class_exists('X')` → `class_exists('X', false)` bei allen Guard-Aufrufen. Der Parameter `false` weist PHP an, nur im Speicher zu prüfen ob die Klasse existiert, ohne Autoloader auszulösen.

- **128 Guard-Aufrufe geändert** in **87 Dateien**
- **27 Runtime-Dispatch-Aufrufe unverändert** (diese prüfen absichtlich auf externe Klassen wie `IntlDateFormatter`)

### Warum gegen `development`?

Dieser PR basiert auf dem `development`-Branch (OES 3.0.0 Vorbereitung), da dort die aktive Entwicklung stattfindet und der Bug auch in der neuen Version noch vorhanden ist.

---

## Summary (EN)

This PR adds the `false` parameter to all `class_exists()` guard calls in `includes/` to prevent autoloader collisions with third-party plugins.

### Problem

When OES Core is used alongside plugins that register PHP autoloaders (e.g. WooCommerce with Action Scheduler and Jetpack Autoloader), `class_exists('ClassName')` calls without `false` trigger all registered autoloaders as a side effect. Short, unqualified class names like `'Config'`, `'Container'`, or `'Page'` are incorrectly matched by external autoloaders, which then load classes from the wrong namespace, causing fatal errors.

### Errors observed

1. **`Cannot declare class Action_Scheduler\Migration\Config, because the name is already in use`** — OES calls `class_exists('Config')` → Action Scheduler autoloader matches `Config` as a migration class → loads `migration/Config.php` → on a second call, PHP attempts to redeclare it → fatal error.

2. **`Class "OES\Admin\Container" not found`** — OES calls `class_exists('Container')` → Jetpack Autoloader loads its own global `\Container` class → guard returns `true` → OES skips declaring `OES\Admin\Container` → later code tries to instantiate it → fatal error.

### Fix

Added `false` as the second argument to all `class_exists()` guard calls:

```php
// Before (triggers autoloaders):
if (!class_exists('Config')) oes_include('admin/tools/config/class-config.php');

// After (no autoloader triggered):
if (!class_exists('Config', false)) oes_include('admin/tools/config/class-config.php');
```

### Scope

- **128 guard calls changed** across **87 files** in `includes/`
- **27 runtime dispatch calls left unchanged** (these intentionally check for external class availability)

### Three guard patterns affected

1. Before class declaration: `if (!class_exists('X')) { class X ... }`
2. Before `oes_include()`: `if (!class_exists('Config')) oes_include(...)`
3. Exit guard: `if (class_exists('Schema')) exit;`

### Environment tested

- WordPress 7.0
- OES Core 2.4.x and development branch (3.0.0)
- WooCommerce 10.7.0
- PHP 8.3

After applying this fix, OES Core and WooCommerce run side by side without fatal errors.